### PR TITLE
v0.1.1

### DIFF
--- a/contracts/Zion.sol
+++ b/contracts/Zion.sol
@@ -114,6 +114,7 @@ contract Zion is ZionGroth16Mixer {
         for (uint i = 0; i < jsOut; i++) {
             emit TradeInitiated(commitments[i]);
             pendingCommitments[commitments[i]] = ZethProof(a,b,c,vk,sigma,input,pk_sender,ciphertext0,ciphertext1);
+            isPendingCommitment[commitments[i]] = true;
         }
     }
 
@@ -166,6 +167,7 @@ contract Zion is ZionGroth16Mixer {
             emit TradeResponded(_initiatorCommitment, commitments[i]);
             // cache the data to be used later on
             pendingCommitments[commitments[i]] = ZethProof(a,b,c,vk,sigma,input,pk_sender,ciphertext0,ciphertext1);
+            isPendingCommitment[commitments[i]] = true;
         }
     }
 

--- a/contracts/ZionGroth16Mixer.sol
+++ b/contracts/ZionGroth16Mixer.sol
@@ -110,7 +110,7 @@ contract ZionGroth16Mixer is BaseZionMixer {
 
         // 6. Emit the all the coins' secret data encrypted with the recipients'
         // respective keys
-        emit_ciphertexts(pk_sender, ciphertext0, ciphertext1);
+        emit_pending_ciphertexts(pk_sender, ciphertext0, ciphertext1);
 
         return commitments;
     }

--- a/contracts/zeth-contracts/BaseZionMixer.sol
+++ b/contracts/zeth-contracts/BaseZionMixer.sol
@@ -134,6 +134,7 @@ contract BaseZionMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     // is key to obfuscate the transaction graph while enabling on-chain storage
     // of the coins' data (useful to ease backup of user's wallets)
     event LogSecretCiphers(bytes32 pk_sender, bytes ciphertext);
+    event LogPendingCommitmentCipher(bytes32 pk_sender, bytes ciphertext);
 
     // Event to emit the nullifiers for the mix call.
     event LogNullifier(bytes32 nullifier);
@@ -491,5 +492,14 @@ contract BaseZionMixer is MerkleTreeMiMC7, ERC223ReceivingContract {
     internal {
         emit LogSecretCiphers(pk_sender, ciphertext0);
         emit LogSecretCiphers(pk_sender, ciphertext1);
+    }
+
+    function emit_pending_ciphertexts(
+        bytes32 pk_sender,
+        bytes memory ciphertext0,
+        bytes memory ciphertext1)
+    internal {
+        emit LogPendingCommitmentCipher(pk_sender, ciphertext0);
+        emit LogPendingCommitmentCipher(pk_sender, ciphertext1);
     }
 }


### PR DESCRIPTION
Fixed bug where shallow verification was emitting Zeth logs which cause notes to not be scannable by PyClient.

Fixed bug where boolean checks on Zion trades failed because the boolean was not initiated when the trade was inserted.

